### PR TITLE
allow to choose different scanning patterns of a lidar module

### DIFF
--- a/include/ignition/rendering/GpuRays.hh
+++ b/include/ignition/rendering/GpuRays.hh
@@ -190,6 +190,9 @@ namespace ignition
       /// \return The vertical resolution.
       /// \sa VerticalRayCount()
       public: virtual double VerticalResolution() const = 0;
+
+      /// \brief Set the scanning pattern
+      public: virtual void SetScanningPattern(const std::string pattern) = 0;
     };
   }
   }

--- a/include/ignition/rendering/GpuRays.hh
+++ b/include/ignition/rendering/GpuRays.hh
@@ -32,6 +32,13 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
+
+    enum class ScanningPattern
+    {
+      AVIA,
+      RASTERIZATION,
+    };
+
     /// \class GpuRays GpuRays.hh ignition/rendering/GpuRays.hh
     /// \brief Generate depth ray data.
     class IGNITION_RENDERING_VISIBLE GpuRays :
@@ -192,7 +199,7 @@ namespace ignition
       public: virtual double VerticalResolution() const = 0;
 
       /// \brief Set the scanning pattern
-      public: virtual void SetScanningPattern(const std::string pattern) = 0;
+      public: virtual void SetScanningPattern(const ScanningPattern pattern) = 0;
     };
   }
   }

--- a/include/ignition/rendering/base/BaseGpuRays.hh
+++ b/include/ignition/rendering/base/BaseGpuRays.hh
@@ -152,7 +152,7 @@ namespace ignition
       public: virtual double VerticalResolution() const override;
 
       // Documentation inherited.
-      public: virtual void SetScanningPattern(const std::string pattern) override;
+      public: virtual void SetScanningPattern(ScanningPattern pattern) override;
 
       /// \brief maximum value used for data outside sensor range
       public: float dataMaxVal = ignition::math::INF_D;
@@ -204,7 +204,7 @@ namespace ignition
       protected: unsigned int channels = 1u;
 
       /// \brief Scanning Pattern
-      protected: std::string scanningPattern = "avia";
+      protected: ScanningPattern pattern = ScanningPattern::AVIA;
 
       private: friend class OgreScene;
     };
@@ -455,12 +455,9 @@ namespace ignition
 
     template <class T>
     //////////////////////////////////////////////////
-    void BaseGpuRays<T>::SetScanningPattern(const std::string pattern)
+    void BaseGpuRays<T>::SetScanningPattern(const ScanningPattern pattern)
     {
-      if (pattern == "rasterizing")
-      {
-        this->scanningPattern = pattern;
-      }
+        this->pattern = pattern;
     }
     }
   }

--- a/include/ignition/rendering/base/BaseGpuRays.hh
+++ b/include/ignition/rendering/base/BaseGpuRays.hh
@@ -151,6 +151,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual double VerticalResolution() const override;
 
+      // Documentation inherited.
+      public: virtual void SetScanningPattern(const std::string pattern) override;
+
       /// \brief maximum value used for data outside sensor range
       public: float dataMaxVal = ignition::math::INF_D;
 
@@ -199,6 +202,9 @@ namespace ignition
 
       /// \brief Number of channels used to store the data
       protected: unsigned int channels = 1u;
+
+      /// \brief Scanning Pattern
+      protected: std::string scanningPattern = "avia";
 
       private: friend class OgreScene;
     };
@@ -445,6 +451,16 @@ namespace ignition
     double BaseGpuRays<T>::VerticalResolution() const
     {
       return this->vResolution;
+    }
+
+    template <class T>
+    //////////////////////////////////////////////////
+    void BaseGpuRays<T>::SetScanningPattern(const std::string pattern)
+    {
+      if (pattern == "rasterizing")
+      {
+        this->scanningPattern = pattern;
+      }
     }
     }
   }

--- a/include/ignition/rendering/base/BaseGpuRays.hh
+++ b/include/ignition/rendering/base/BaseGpuRays.hh
@@ -152,7 +152,7 @@ namespace ignition
       public: virtual double VerticalResolution() const override;
 
       // Documentation inherited.
-      public: virtual void SetScanningPattern(ScanningPattern pattern) override;
+      public: virtual void SetScanningPattern(const ScanningPattern pattern) override;
 
       /// \brief maximum value used for data outside sensor range
       public: float dataMaxVal = ignition::math::INF_D;

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -794,7 +794,7 @@ void Ogre2GpuRays::UpdateSampleTexture()
     {
       unsigned index = i * this->dataPtr->w2nd + j;
 
-      float x, y, dx, dy;
+      float x = 0.0f, y = 0.0f, dx = 0.0f, dy = 0.0f;
       if (this->pattern == ScanningPattern::AVIA)
       {
         dx =  std::get<0>(points[index]);

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -781,6 +781,13 @@ void Ogre2GpuRays::UpdateSampleTexture()
       auto [x, y] = points[index];
       x = hmin + (x + 1) / 2 * (hmax - hmin);
       y = vmin + (y + 1) / 2 * (vmax - vmin);
+
+      if (this->scanningPattern == "rasterizing")
+      {
+        x = hmin + (i + 1) * (hmax - hmin) / this->dataPtr->h2nd;
+        y = vmin + (j + 1) * (vmax - vmin) / this->dataPtr->w2nd;
+      }
+
       this->dataPtr->rayDirections[index] = {x, y};
 
       // set up dir vector to sample from a standard Y up cubemap


### PR DESCRIPTION
<!---
Pull Request Template
- Please fill the sections below as described in the comments.
- This information simplifies collaboration and helps future readers.
- Reviewers should ask for this info to be filled when missing.
-->

<!---
PR Metadata
- Title: Provide a short summary of the PR changes.
- Assignees: Assign yourself and other direct collaborators.
- Type: Create the PR as a draft. Only set it to non-draft when it is ready to be reviewed.
- Reviewers: Only assign reviewers when the PR is ready to be reviewed.
- Labels: Only assign labels with high priority and important context. Default is label-less.
-->

### Description
<!--- Describe your changes in detail -->
<!--- If there are other links relevant to this PR, mention them here as well -->

Allow the user to choose scanning patterns in `avia` and `rasterizing` in an sdf file.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

To support multiple lidar scanning patterns based on real-world cases.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Readers can use this info to verify or try the changes. -->
<!--- - Code snippet with the commands you used to test this locally. -->
<!--- - Link to relevant CI run. -->
<!--- - Other useful info for reviewers. -->

Shared the result to other engineers.

### Checklist
<!--- Put an `x` in the boxes that apply. -->

- [x] Have you filled the sections above?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same GitHub Issues/ClickUp Task(s)?
- [ ] Have you documented the changes in GitHub Issues and/or ClickUp Task(s) related to this Pull Request?
- [x] Have you added labels, where appropriate, to this Pull Request?

<!--
Do not include screenshots.
- These will be accessible from everyone outside DeepX-inc.
- Add them to the ClickUp task instead.
-->